### PR TITLE
Remove unused java8 feature, builds with java7 now.

### DIFF
--- a/src/main/java/org/konstructs/forest/ForestConfig.java
+++ b/src/main/java/org/konstructs/forest/ForestConfig.java
@@ -1,7 +1,5 @@
 package konstructs.forest;
 
-import java.time.Duration;
-
 import konstructs.api.BlockTypeId;
 
 public class ForestConfig {


### PR DESCRIPTION
The import was never used, and it prevented you to build the project with java7.
